### PR TITLE
Docs edit

### DIFF
--- a/templates/databricks-multi-workspace.template.yaml
+++ b/templates/databricks-multi-workspace.template.yaml
@@ -4,7 +4,7 @@ Description: >-
   
 Metadata:
   QuickStartDocumentation:
-    EntrypointName: "Launch multi-workspace environment"
+    EntrypointName: "Parameters for launching a multi-workspace environment"
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:


### PR DESCRIPTION
To make the TOC more useful, I changed `EntrypointName` from "**Launch** a multi-workspace environment" to "**Parameters for launching** a multi-workspace environment." See [this TOC](https://aws-quickstart.github.io/quickstart-citrix-adc-waf/#_parameters_for_launching_into_a_new_vpc) for an example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
