### PR TITLE
Changed the parameter EntrypointName to match our standard language

### DIFF
--- a/templates/databricks-multi-workspace.template.yaml
+++ b/templates/databricks-multi-workspace.template.yaml
@@ -7,7 +7,7 @@ Metadata:
     - Multiworkspace
     - multiworkspace
   QuickStartDocumentation:
-    EntrypointName: "Parameters for launching a multiworkspace environment"
+    EntrypointName: "Parameters for launching into an existing VPC"
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:


### PR DESCRIPTION
Changed the parameter `EntrypointName` to match our standard language: "Parameters for launching into an existing VPC"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
