### PR TITLE
Provisioning Started SQL Warehouse

### DIFF
--- a/functions/source/WorkspaceManager.py
+++ b/functions/source/WorkspaceManager.py
@@ -57,3 +57,32 @@ class WorkspaceManager:
   # Terminates a cluster
   def terminateCluster(self, clusterId: str):
     _ = self.__workspaceApiSession.post('/clusters/permanent-delete', { "cluster_id": clusterId })
+
+  # Creates a starter SQL Warehouse
+  def createStarterWarehouseCluster(self):
+    warehouseData = {
+      "name": "[default]basic-starter-warehouse",
+      "cluster_size": "Medium",
+      "min_num_clusters": 1,
+      "max_num_clusters": 5,
+      "spot_instance_policy":"COST_OPTIMIZED",
+      "enable_photon": "true",
+      "enable_serverless_compute": "true",
+      "warehouse_type": "PRO",
+      "channel": {
+      "name": "CHANNEL_NAME_CURRENT"
+      },
+      "tags": {
+      "custom_tags": {
+          "ResourceClass": "SingleNode",
+          "DatabricksDefault": True,
+          "Origin": "AWSQuickstartCloudformationLambda"
+      }
+      }
+    }
+    response = self.__workspaceApiSession.post('/api/2.0/sql/warehouses', warehouseData)
+    return response['id']
+
+  # Terminates a cluster
+  def terminateWarehouseCluster(self, warehouseClusterId: str):
+    _ = self.__workspaceApiSession.delete('/api/2.0/sql/warehouses{}'.format(warehouseClusterId))

--- a/functions/source/rest_client.py
+++ b/functions/source/rest_client.py
@@ -242,7 +242,17 @@ def handler(event, context):
             # deletion
             elif event['RequestType'] == 'Delete':
                 workspaceManager.terminateCluster(physicalResourceId)
-    
+
+        # Creating a Starter WarehouseCluster
+        elif action == 'CREATE_STARTER_WAREHOUSE':
+            checkForMissingProperties(event, ['workspace_deployment_name'])
+            workspaceManager = WorkspaceManager(apiSession, event['ResourceProperties']['workspace_deployment_name'])
+            if event['RequestType'] == 'Create':
+                physicalResourceId = workspaceManager.createStarterWarehouseCluster()
+            # deletion
+            elif event['RequestType'] == 'Delete':
+                workspaceManager.terminateWarehouseCluster(physicalResourceId)
+
     except Exception as e:
         reason = str(e)
         logging.exception(reason)

--- a/templates/databricks-multi-workspace-oem.template.yaml
+++ b/templates/databricks-multi-workspace-oem.template.yaml
@@ -1287,6 +1287,18 @@ Resources:
       instance_profile_arn: !If [CreateDefaultInstanceProfile, !Ref registerInstanceProfile, !Ref AWS::NoValue]
       policy_id: !If [ShouldCreateHipaaClusterPolicy, !Ref createHipaaClusterPolicy, !Ref AWS::NoValue]
       user_agent: 'databricks-CloudFormation-OEM-provider'
+  
+  # Creates a starter warehouse cluster
+  createStarterWarehouseCluster:
+    Type: Custom::createStarterWarehouseCluster
+    Properties:
+      ServiceToken: !GetAtt databricksApiFunction.Arn
+      action: CREATE_STARTER_WAREHOUSE
+      accountId: !Ref AccountId
+      username: !Ref Username
+      password: !Ref Password
+      workspace_deployment_name: !GetAtt createWorkspace.DeploymentName
+      user_agent: 'databricks-CloudFormation-OEM-provider'
 
   # Customer managed Keys - Update Storage policy for S3 and EBS volumes 
   updateCustomManagedKeys:

--- a/templates/databricks-multi-workspace-withoutIAM.template.yaml
+++ b/templates/databricks-multi-workspace-withoutIAM.template.yaml
@@ -1021,6 +1021,19 @@ Resources:
       policy_id: !If [ShouldCreateHipaaClusterPolicy, !Ref createHipaaClusterPolicy, !Ref AWS::NoValue]
       user_agent: databricks-CloudFormation-provider
 
+  # Creates a starter warehouse cluster
+  createStarterWarehouseCluster:
+    Type: Custom::createStarterWarehouseCluster
+    Properties:
+      ServiceToken: !GetAtt databricksApiFunction.Arn
+      action: CREATE_STARTER_WAREHOUSE
+      accountId: !Ref AccountId
+      username: !Ref Username
+      password: !Ref Password
+      workspace_deployment_name: !GetAtt createWorkspace.DeploymentName
+      user_agent: 'databricks-CloudFormation-provider'
+
+
   # Customer managed Keys - Update policy for S3 and EBS volumes 
   updateCustomManagedKeys:
     Condition: IsKMSKeyProvided

--- a/templates/databricks-multi-workspace.template.yaml
+++ b/templates/databricks-multi-workspace.template.yaml
@@ -1257,6 +1257,18 @@ Resources:
       policy_id: !If [ShouldCreateHipaaClusterPolicy, !Ref createHipaaClusterPolicy, !Ref AWS::NoValue]
       user_agent: databricks-CloudFormation-provider
 
+  # Creates a starter warehouse cluster
+  createStarterWarehouseCluster:
+    Type: Custom::createStarterWarehouseCluster
+    Properties:
+      ServiceToken: !GetAtt databricksApiFunction.Arn
+      action: CREATE_STARTER_WAREHOUSE
+      accountId: !Ref AccountId
+      username: !Ref Username
+      password: !Ref Password
+      workspace_deployment_name: !GetAtt createWorkspace.DeploymentName
+      user_agent: 'databricks-CloudFormation-provider'
+
   # Customer managed Keys - Update Storage policy for S3 and EBS volumes 
   updateCustomManagedKeys:
     Condition: IsKMSKeyProvided

--- a/templates/databricks-trial.template.yaml
+++ b/templates/databricks-trial.template.yaml
@@ -914,6 +914,18 @@ Resources:
       instance_profile_arn: !If [CreateDefaultInstanceProfile, !Ref registerInstanceProfile, !Ref AWS::NoValue]
       user_agent: databricks-CloudFormation-Trial-provider
 
+  # Creates a starter warehouse cluster
+  createStarterWarehouseCluster:
+    Type: Custom::createStarterWarehouseCluster
+    Properties:
+      ServiceToken: !GetAtt databricksApiFunction.Arn
+      action: CREATE_STARTER_WAREHOUSE
+      accountId: !Ref AccountId
+      username: !Ref Username
+      password: !Ref Password
+      workspace_deployment_name: !GetAtt createWorkspace.DeploymentName
+      user_agent: 'databricks-CloudFormation-Trial-provider'
+
   # The Lambda for the custom resources
   databricksApiFunction:
     DependsOn: CopyZips


### PR DESCRIPTION
Creating SQL Warehouse starter cluster #86

Added provisioning to create SQL Warehouse Started with cf. A Default SQL Warehouse is created with default config. Creates only the SQL Warehouse Cluster. Doesn't change any warehouse settings that affects all warehouse.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
