### PR TITLE
1.-added cross account role policies to modify customer vpc security …

### DIFF
--- a/templates/databricks-multi-workspace.template.yaml
+++ b/templates/databricks-multi-workspace.template.yaml
@@ -914,6 +914,18 @@ Resources:
                   - 'ec2:RequestSpotInstances'
                 Resource:
                   - '*'
+              - Sid: ModifySecurityGroupRules
+                Effect: Allow
+                Action:
+                  - 'ec2:RevokeSecurityGroupIngress'
+                  - 'ec2:AuthorizeSecurityGroupEgress'
+                  - 'ec2:AuthorizeSecurityGroupIngress'
+                  - 'ec2:UpdateSecurityGroupRuleDescriptionsEgress'
+                  - 'ec2:RevokeSecurityGroupEgress'
+                  - 'ec2:ModifySecurityGroupRules'
+                  - 'ec2:UpdateSecurityGroupRuleDescriptionsIngress'
+                Resource:
+                  - '*'
               - Sid: InstancePoolsSupport
                 Effect: Allow
                 Action:
@@ -1206,7 +1218,6 @@ Resources:
       username: !Ref Username
       password: !Ref Password
       workspace_name: !If [IsDeploymentNameSet, !Sub '${DeploymentName}-workspace', !Sub '${AWS::StackName}-workspace']
-      deployment_name: !Ref DeploymentName
       aws_region: !Ref AWS::Region
       credentials_id: !Ref createCredentials
       storage_config_id: !Ref createStorageConfiguration


### PR DESCRIPTION
#83
*Issue #, if available:*
1.- When creating a workspace IAM policies to modify security group ingress rules are necessary. Feel free to fine tune as you see fit.
2.-CF stack creation breaking issue: when calling the Create Workspace API endpoint databrick API asks for a pre-requisite to be set that cannot be found anywhere in the GUI or the API itself: the deployment name prefix and therefore throws an error if deployment_name is passed:
"Deployment name cannot be used until a deployment name prefix is defined"
Update: In the main Get Started Guide for Custom Workspace Configurations we found a link explaining that in order to set the Deployment name space databricks needs to be contacted, this should be mentioned on the template documentation to avoid confusion or be made a Condition to include the deployment_name field in the createWorkspace Custom Resource:
https://docs.databricks.com/en/administration-guide/workspace/create-workspace.html#create-a-workspace-with-custom-aws-configurations
which leads to:
https://docs.databricks.com/en/administration-guide/workspace/create-workspace.html#name



*Description of changes:*
1.Added placeholder statement to support Security Group ingress/egress rules in the Cross Account IAM role Policy. Please fine tune the Resources to use security group input parameter.
2.-Removing deployment_name input from the createWorkspace custom resource 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
